### PR TITLE
Keep initial subscriptions alive

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -100,7 +100,7 @@ export default (mapFirebaseToProps = defaultMapFirebaseToProps, mergeProps = def
           }
         })
 
-        this.listeners = nextListeners
+        this.listeners = { ...this.listeners, ...nextListeners }
       }
 
       unsubscribe(subscriptions) {


### PR DESCRIPTION
Hello guys,

I think your last commits removed the already existing subscriptions and imply some errors when trying to unsubscribe a non-existant listener. I guess it's because in the previous version was used a `reduce` function instead of the `mapValues`.

Hope it's ok for you.