### PR TITLE
New API: <Firebase /> with query and render props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "@unfold/eslint-config"
+  "extends": "@unfold/eslint-config",
+  "rules": {
+    "no-return-assign": 0
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 coverage/
 node_modules/
-index.js
-Provider.js
-connect.js
-utils.js
-umd.js
+/index.js
+/Provider.js
+/connect.js
+/utils.js
+/umd.js
+/Firebase.js

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 /utils.js
 /umd.js
 /Firebase.js
+/withFirebase.js

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
   "scripts": {
     "lint": "eslint '{src,scripts,tests}/**/*.js'",
     "test": "node -r babel-register $(npm bin)/tape tests/**/*-test.js",
-    "test:coverage": "node -r babel-register $(npm bin)/isparta cover $(npm bin)/tape -- src/**/*-test.js",
+    "test:coverage":
+      "node -r babel-register $(npm bin)/isparta cover $(npm bin)/tape -- src/**/*-test.js",
     "clean": "node -e 'console.log(require(\"./package\").files.join(\"\\n\"))' | xargs rm",
     "build": "babel src --ignore tests --out-dir .",
     "postbuild": "node -r babel-register scripts/build-umd.js",
     "prepublish": "npm run build",
     "postpublish": "npm run clean",
-    "format": "prettier --trailing-comma all --single-quote --no-semi --print-width 100 --write {src,scripts,tests}/**/*.js",
+    "format":
+      "prettier --trailing-comma all --single-quote --no-semi --print-width 100 --write {src,scripts,tests}/**/*.js",
     "precommit": "lint-staged"
   },
   "unpkg": "umd.js",
@@ -27,16 +29,13 @@
   "files": [
     "index.js",
     "Firebase.js",
+    "withFirebase.js",
     "Provider.js",
     "connect.js",
     "utils.js",
     "umd.js"
   ],
-  "keywords": [
-    "react",
-    "reactjs",
-    "firebase"
-  ],
+  "keywords": ["react", "reactjs", "firebase"],
   "lint-staged": {
     "{src,scripts,tests}/**/*.js": [
       "prettier --trailing-comma all --single-quote --no-semi --print-width 100 --write",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-firebase",
-  "version": "2.2.7-2",
+  "version": "2.2.7-3",
   "description": "React bindings for Firebase",
   "author": "Unfold <github@unfold.no> (http://github.com/unfold)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "index.js",
+    "Firebase.js",
     "Provider.js",
     "connect.js",
     "utils.js",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "postbuild": "node -r babel-register scripts/build-umd.js",
     "prepublish": "npm run build",
     "postpublish": "npm run clean",
+    "format": "prettier --trailing-comma all --single-quote --no-semi --print-width 100 --write {src,scripts,tests}/**/*.js",
     "precommit": "lint-staged"
   },
   "unpkg": "umd.js",
@@ -38,31 +39,29 @@
   ],
   "lint-staged": {
     "{src,scripts,tests}/**/*.js": [
-      "prettier --trailing-comma es5 --single-quote --no-semi --print-width 100 --write",
+      "prettier --trailing-comma all --single-quote --no-semi --print-width 100 --write",
       "git add"
     ]
   },
   "homepage": "https://github.com/unfold/react-firebase",
   "devDependencies": {
     "@unfold/babel-preset": "^1.0.2",
-    "@unfold/eslint-config": "^1.3.2",
+    "@unfold/eslint-config": "^3.0.0",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.7.4",
-    "babel-eslint": "^7.1.1",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.18.0",
     "eslint": "^3.10.2",
-    "eslint-plugin-react": "^6.7.1",
     "firebase": "^3.6.1",
     "husky": "^0.13.3",
     "isparta": "^4.0.0",
     "jsdom": "^9.8.3",
     "jsdom-global": "^2.1.0",
     "lint-staged": "^3.4.2",
-    "prettier": "^1.3.1",
+    "prettier": "^1.7.4",
     "react": "^0.14.8 || ^15.0.0",
     "react-addons-test-utils": "^0.14.8 || ^15.0.0",
     "react-dom": "^0.14.8 || ^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-firebase",
-  "version": "2.2.7-3",
+  "version": "2.2.7-4",
   "description": "React bindings for Firebase",
   "author": "Unfold <github@unfold.no> (http://github.com/unfold)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-firebase",
-  "version": "2.2.7-0",
+  "version": "2.2.7-1",
   "description": "React bindings for Firebase",
   "author": "Unfold <github@unfold.no> (http://github.com/unfold)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-firebase",
-  "version": "2.2.6",
+  "version": "2.2.7-0",
   "description": "React bindings for Firebase",
   "author": "Unfold <github@unfold.no> (http://github.com/unfold)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,21 +1,19 @@
 {
   "name": "react-firebase",
-  "version": "2.2.7-1",
+  "version": "2.2.7-2",
   "description": "React bindings for Firebase",
   "author": "Unfold <github@unfold.no> (http://github.com/unfold)",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,scripts,tests}/**/*.js'",
     "test": "node -r babel-register $(npm bin)/tape tests/**/*-test.js",
-    "test:coverage":
-      "node -r babel-register $(npm bin)/isparta cover $(npm bin)/tape -- src/**/*-test.js",
+    "test:coverage": "node -r babel-register $(npm bin)/isparta cover $(npm bin)/tape -- src/**/*-test.js",
     "clean": "node -e 'console.log(require(\"./package\").files.join(\"\\n\"))' | xargs rm",
     "build": "babel src --ignore tests --out-dir .",
     "postbuild": "node -r babel-register scripts/build-umd.js",
     "prepublish": "npm run build",
     "postpublish": "npm run clean",
-    "format":
-      "prettier --trailing-comma all --single-quote --no-semi --print-width 100 --write {src,scripts,tests}/**/*.js",
+    "format": "prettier --trailing-comma all --single-quote --no-semi --print-width 100 --write {src,scripts,tests}/**/*.js",
     "precommit": "lint-staged"
   },
   "unpkg": "umd.js",
@@ -35,7 +33,11 @@
     "utils.js",
     "umd.js"
   ],
-  "keywords": ["react", "reactjs", "firebase"],
+  "keywords": [
+    "react",
+    "reactjs",
+    "firebase"
+  ],
   "lint-staged": {
     "{src,scripts,tests}/**/*.js": [
       "prettier --trailing-comma all --single-quote --no-semi --print-width 100 --write",

--- a/scripts/build-umd.js
+++ b/scripts/build-umd.js
@@ -44,7 +44,7 @@ webpack(
         chunks: false,
         version: false,
         hash: false,
-      })
+      }),
     )
-  }
+  },
 )

--- a/src/Firebase.js
+++ b/src/Firebase.js
@@ -1,0 +1,147 @@
+/* eslint-disable react/no-unused-prop-types, react/sort-comp */
+
+import React from 'react'
+import firebase from 'firebase/app'
+import PropTypes from 'prop-types'
+import { createQueryRef, mapValues, mapSnapshotToValue, pickBy } from './utils'
+
+const mapSubscriptionsToQueries = subscriptions =>
+  mapValues(subscriptions, value => (typeof value === 'string' ? { path: value } : value))
+
+const getQuery = (props, ref) => {
+  switch (typeof props.query) {
+    case 'string':
+      return { [props.query]: props.query }
+    case 'function':
+      return props.query(ref)
+    default:
+      return props.query
+  }
+}
+
+const getSubscriptions = (props, ref) =>
+  pickBy(getQuery(props, ref), prop => typeof prop === 'string' || (prop && prop.path))
+
+const getActions = (props, ref) => pickBy(getQuery(props, ref), prop => typeof prop === 'function')
+
+export default class Firebase extends React.Component {
+  static propTypes = {
+    render: PropTypes.func.isRequired,
+    query: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.func]).isRequired,
+    firebaseApp: PropTypes.shape({
+      database: PropTypes.func.isRequired,
+    }),
+  }
+
+  static contextTypes = {
+    firebaseApp: PropTypes.shape({
+      database: PropTypes.func.isRequired,
+    }),
+  }
+
+  state = {
+    subscriptionsState: null,
+  }
+
+  componentDidMount() {
+    this.mounted = true
+    this.subscribe(getSubscriptions(this.props))
+  }
+
+  componentWillReceiveProps(nextProps, nextContext) {
+    const ref = this.getRef(nextProps, nextContext)
+    const subscriptions = getSubscriptions(this.props, ref)
+    const nextSubscriptions = getSubscriptions(nextProps, ref)
+    const addedSubscriptions = pickBy(nextSubscriptions, (path, key) => !subscriptions[key])
+    const removedSubscriptions = pickBy(subscriptions, (path, key) => !nextSubscriptions[key])
+    const changedSubscriptions = pickBy(
+      nextSubscriptions,
+      (path, key) => subscriptions[key] && subscriptions[key] !== path
+    )
+
+    this.unsubscribe({ ...removedSubscriptions, ...changedSubscriptions })
+    this.subscribe({ ...addedSubscriptions, ...changedSubscriptions }, ref)
+  }
+
+  componentWillUnmount() {
+    this.mounted = false
+
+    if (this.listeners) {
+      this.unsubscribe(this.listeners)
+    }
+  }
+
+  subscribe(subscriptions, ref = this.getRef()) {
+    if (Object.keys(subscriptions).length < 1) {
+      return
+    }
+
+    const queries = mapSubscriptionsToQueries(subscriptions)
+    const nextListeners = mapValues(queries, ({ path, ...query }, key) => {
+      const containsOrderBy = Object.keys(query).some(queryKey => queryKey.startsWith('orderBy'))
+      const subscriptionRef = createQueryRef(ref(path), query)
+      const update = snapshot => {
+        if (this.mounted) {
+          const value = containsOrderBy ? mapSnapshotToValue(snapshot) : snapshot.val()
+
+          this.setState(prevState => ({
+            subscriptionsState: {
+              ...prevState.subscriptionsState,
+              [key]: value,
+            },
+          }))
+        }
+      }
+
+      subscriptionRef.on('value', update)
+
+      return {
+        path,
+        unsubscribe: () => subscriptionRef.off('value', update),
+      }
+    })
+
+    this.listeners = { ...this.listeners, ...nextListeners }
+  }
+
+  unsubscribe(subscriptions) {
+    if (Object.keys(subscriptions).length < 1) {
+      return
+    }
+
+    const nextListeners = { ...this.listeners }
+    const nextSubscriptionsState = { ...this.state.subscriptionsState }
+
+    Object.keys(subscriptions).forEach(key => {
+      const subscription = this.listeners[key]
+      subscription.unsubscribe()
+
+      delete nextListeners[key]
+      delete nextSubscriptionsState[key]
+    })
+
+    this.listeners = nextListeners
+    this.setState({ subscriptionsState: nextSubscriptionsState })
+  }
+
+  getRef(props, context) {
+    return path => this.getFirebaseApp(props, context).database().ref(path)
+  }
+
+  getFirebaseApp(props = this.props, context = this.context) {
+    return props.firebaseApp || context.firebaseApp || firebase.app()
+  }
+
+  render() {
+    const firebaseProps = {
+      ...getActions(this.props, this.getRef()),
+      ...this.state.subscriptionsState,
+    }
+
+    if (this.props.render) {
+      return this.props.render(firebaseProps)
+    }
+
+    return null
+  }
+}

--- a/src/Firebase.js
+++ b/src/Firebase.js
@@ -26,7 +26,8 @@ const getActions = (props, ref, app) =>
 export default class Firebase extends React.Component {
   static propTypes = {
     render: PropTypes.func.isRequired,
-    query: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.func]).isRequired,
+    query: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.func]),
+    children: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.func]),
     firebaseApp: PropTypes.instanceOf(firebase.app.App), // eslint-disable-line react/no-unused-prop-types
   }
 
@@ -36,6 +37,7 @@ export default class Firebase extends React.Component {
 
   state = {
     subscriptionsState: {},
+    connected: false,
   }
 
   componentDidMount() {
@@ -104,6 +106,7 @@ export default class Firebase extends React.Component {
           const value = containsOrderBy ? mapSnapshotToValue(snapshot) : snapshot.val()
 
           this.setState(prevState => ({
+            connected: true,
             subscriptionsState: {
               ...prevState.subscriptionsState,
               [key]: value,
@@ -144,6 +147,12 @@ export default class Firebase extends React.Component {
   }
 
   render() {
-    return this.props.render(this.getFirebaseProps())
+    if (this.state.connected && this.props.render) {
+      return this.props.render(this.getFirebaseProps())
+    } else if (this.props.children) {
+      return this.props.children(this.getFirebaseProps())
+    }
+
+    return null
   }
 }

--- a/src/Firebase.js
+++ b/src/Firebase.js
@@ -27,15 +27,11 @@ export default class Firebase extends React.Component {
   static propTypes = {
     render: PropTypes.func.isRequired,
     query: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.func]).isRequired,
-    firebaseApp: PropTypes.shape({
-      database: PropTypes.func.isRequired,
-    }),
+    firebaseApp: PropTypes.instanceOf(firebase.app.App), // eslint-disable-line react/no-unused-prop-types
   }
 
   static contextTypes = {
-    firebaseApp: PropTypes.shape({
-      database: PropTypes.func.isRequired,
-    }),
+    firebaseApp: PropTypes.instanceOf(firebase.app.App),
   }
 
   state = {
@@ -57,7 +53,7 @@ export default class Firebase extends React.Component {
     const removedSubscriptions = pickBy(subscriptions, (path, key) => !nextSubscriptions[key])
     const changedSubscriptions = pickBy(
       nextSubscriptions,
-      (path, key) => subscriptions[key] && subscriptions[key] !== path
+      (path, key) => subscriptions[key] && subscriptions[key] !== path,
     )
 
     this.unsubscribe({ ...removedSubscriptions, ...changedSubscriptions })
@@ -73,7 +69,10 @@ export default class Firebase extends React.Component {
   }
 
   getRef(props, context) {
-    return path => this.getFirebaseApp(props, context).database().ref(path)
+    return path =>
+      this.getFirebaseApp(props, context)
+        .database()
+        .ref(path)
   }
 
   getFirebaseApp(props = this.props, context = this.context) {

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import { Component, Children } from 'react'
+import firebase from 'firebase/app'
 
 export default class Provider extends Component {
   static propTypes = {
@@ -8,7 +9,7 @@ export default class Provider extends Component {
   }
 
   static childContextTypes = {
-    firebaseApp: PropTypes.object,
+    firebaseApp: PropTypes.instanceOf(firebase.app.App),
   }
 
   getChildContext() {

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import firebase from 'firebase/app'
 import Firebase from './Firebase'
 import { getDisplayName } from './utils'
 
@@ -8,19 +9,18 @@ const defaultMapFirebaseToProps = (props, ref, firebaseApp) => ({
 })
 
 export default (mapFirebaseToProps = defaultMapFirebaseToProps) => WrappedComponent => {
-  const FirebaseConnect = props =>
+  const FirebaseConnect = props => (
     <Firebase
       firebaseApp={props.firebaseApp}
       query={mapFirebaseToProps}
       render={firebaseProps => <WrappedComponent {...firebaseProps} {...props} />}
     />
+  )
 
   FirebaseConnect.WrappedComponent = WrappedComponent
   FirebaseConnect.displayName = `FirebaseConnect(${getDisplayName(WrappedComponent)})`
   FirebaseConnect.propTypes = {
-    firebaseApp: PropTypes.shape({
-      database: PropTypes.func.isRequired,
-    }),
+    firebaseApp: PropTypes.instanceOf(firebase.app.App),
   }
 
   return FirebaseConnect

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,161 +1,29 @@
+/* eslint-disable react/no-unused-prop-types, react/sort-comp */
+
+import React from 'react'
 import PropTypes from 'prop-types'
-import { Component, createElement } from 'react'
-import invariant from 'invariant'
-import firebase from 'firebase/app'
-import 'firebase/database'
-import { createQueryRef, getDisplayName, mapValues, mapSnapshotToValue, pickBy } from './utils'
-
-const defaultMergeProps = (ownProps, firebaseProps) => ({
-  ...ownProps,
-  ...firebaseProps,
-})
-
-const mapSubscriptionsToQueries = subscriptions =>
-  mapValues(subscriptions, value => (typeof value === 'string' ? { path: value } : value))
+import Firebase from './Firebase'
+import { getDisplayName } from './utils'
 
 const defaultMapFirebaseToProps = (props, ref, firebaseApp) => ({
   firebaseApp,
 })
 
-export default (mapFirebaseToProps = defaultMapFirebaseToProps, mergeProps = defaultMergeProps) => {
-  const mapFirebase = typeof mapFirebaseToProps === 'function'
-    ? mapFirebaseToProps
-    : () => mapFirebaseToProps
+export default (mapFirebaseToProps = defaultMapFirebaseToProps) => WrappedComponent => {
+  const FirebaseConnect = props =>
+    <Firebase
+      firebaseApp={props.firebaseApp}
+      query={mapFirebaseToProps}
+      render={firebaseProps => <WrappedComponent {...firebaseProps} {...props} />}
+    />
 
-  const computeSubscriptions = (props, ref, firebaseApp) => {
-    const firebaseProps = mapFirebase(props, ref, firebaseApp)
-    const subscriptions = pickBy(
-      firebaseProps,
-      prop => typeof prop === 'string' || (prop && prop.path)
-    )
-
-    invariant(
-      typeof subscriptions === 'object',
-      '`mapFirebaseToProps` must return an object. Instead received %s.',
-      subscriptions
-    )
-
-    return subscriptions
+  FirebaseConnect.WrappedComponent = WrappedComponent
+  FirebaseConnect.displayName = `FirebaseConnect(${getDisplayName(WrappedComponent)})`
+  FirebaseConnect.propTypes = {
+    firebaseApp: PropTypes.shape({
+      database: PropTypes.func.isRequired,
+    }),
   }
 
-  return WrappedComponent => {
-    class FirebaseConnect extends Component {
-      constructor(props, context) {
-        super(props, context)
-
-        this.firebaseApp = props.firebaseApp || context.firebaseApp || firebase.app()
-        this.ref = path => this.firebaseApp.database().ref(path)
-        this.state = {
-          subscriptionsState: null,
-        }
-      }
-
-      componentDidMount() {
-        const subscriptions = computeSubscriptions(this.props, this.ref, this.firebaseApp)
-
-        this.mounted = true
-        this.subscribe(subscriptions)
-      }
-
-      componentWillReceiveProps(nextProps) {
-        const subscriptions = computeSubscriptions(this.props, this.ref, this.firebaseApp)
-        const nextSubscriptions = computeSubscriptions(nextProps, this.ref, this.firebaseApp)
-        const addedSubscriptions = pickBy(nextSubscriptions, (path, key) => !subscriptions[key])
-        const removedSubscriptions = pickBy(subscriptions, (path, key) => !nextSubscriptions[key])
-        const changedSubscriptions = pickBy(
-          nextSubscriptions,
-          (path, key) => subscriptions[key] && subscriptions[key] !== path
-        )
-
-        this.unsubscribe({ ...removedSubscriptions, ...changedSubscriptions })
-        this.subscribe({ ...addedSubscriptions, ...changedSubscriptions })
-      }
-
-      componentWillUnmount() {
-        this.mounted = false
-
-        if (this.listeners) {
-          this.unsubscribe(this.listeners)
-        }
-      }
-
-      subscribe(subscriptions) {
-        if (Object.keys(subscriptions).length < 1) {
-          return
-        }
-
-        const queries = mapSubscriptionsToQueries(subscriptions)
-        const nextListeners = mapValues(queries, ({ path, ...query }, key) => {
-          const containsOrderBy = Object.keys(query).some(queryKey =>
-            queryKey.startsWith('orderBy')
-          )
-          const subscriptionRef = createQueryRef(this.ref(path), query)
-          const update = snapshot => {
-            if (this.mounted) {
-              const value = containsOrderBy ? mapSnapshotToValue(snapshot) : snapshot.val()
-
-              this.setState(prevState => ({
-                subscriptionsState: {
-                  ...prevState.subscriptionsState,
-                  [key]: value,
-                },
-              }))
-            }
-          }
-
-          subscriptionRef.on('value', update)
-
-          return {
-            path,
-            unsubscribe: () => subscriptionRef.off('value', update),
-          }
-        })
-
-        this.listeners = { ...this.listeners, ...nextListeners }
-      }
-
-      unsubscribe(subscriptions) {
-        if (Object.keys(subscriptions).length < 1) {
-          return
-        }
-
-        const nextListeners = { ...this.listeners }
-        const nextSubscriptionsState = { ...this.state.subscriptionsState }
-
-        Object.keys(subscriptions).forEach(key => {
-          const subscription = this.listeners[key]
-          subscription.unsubscribe()
-
-          delete nextListeners[key]
-          delete nextSubscriptionsState[key]
-        })
-
-        this.listeners = nextListeners
-        this.setState({ subscriptionsState: nextSubscriptionsState })
-      }
-
-      render() {
-        const firebaseProps = mapFirebase(this.props, this.ref, this.firebaseApp)
-        const actionProps = pickBy(firebaseProps, prop => typeof prop === 'function')
-        const subscriptionProps = this.state.subscriptionsState
-        const props = mergeProps(this.props, {
-          ...actionProps,
-          ...subscriptionProps,
-        })
-
-        return createElement(WrappedComponent, props)
-      }
-    }
-
-    FirebaseConnect.WrappedComponent = WrappedComponent
-    FirebaseConnect.defaultProps = Component.defaultProps
-    FirebaseConnect.displayName = `FirebaseConnect(${getDisplayName(WrappedComponent)})`
-    FirebaseConnect.contextTypes = FirebaseConnect.propTypes = {
-      firebaseApp: PropTypes.shape({
-        database: PropTypes.func.isRequired, // eslint-disable-line react/no-unused-prop-types
-      }),
-    }
-
-    return FirebaseConnect
-  }
+  return FirebaseConnect
 }

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-unused-prop-types, react/sort-comp */
-
 import React from 'react'
 import PropTypes from 'prop-types'
 import Firebase from './Firebase'

--- a/src/connect.js
+++ b/src/connect.js
@@ -4,17 +4,21 @@ import firebase from 'firebase/app'
 import Firebase from './Firebase'
 import { getDisplayName } from './utils'
 
-const defaultMapFirebaseToProps = (props, ref, firebaseApp) => ({
-  firebaseApp,
-})
-
-export default (mapFirebaseToProps = defaultMapFirebaseToProps) => WrappedComponent => {
+export default query => WrappedComponent => {
   const FirebaseConnect = props => (
     <Firebase
       firebaseApp={props.firebaseApp}
-      query={mapFirebaseToProps}
-      render={firebaseProps => <WrappedComponent {...firebaseProps} {...props} />}
-    />
+      query={typeof query === 'function' ? query(props) : query}
+    >
+      {(firebaseProps, firebaseRef, firebaseApp) => (
+        <WrappedComponent
+          {...firebaseProps}
+          firebaseRef={firebaseRef}
+          firebaseApp={firebaseApp}
+          {...props}
+        />
+      )}
+    </Firebase>
   )
 
   FirebaseConnect.WrappedComponent = WrappedComponent

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export Provider from './Provider'
 export connect from './connect'
+export withFirebase from './withFirebase'
 export default from './Firebase'

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export Provider from './Provider'
 export connect from './connect'
+export default from './Firebase'

--- a/src/withFirebase.js
+++ b/src/withFirebase.js
@@ -5,20 +5,19 @@ import Firebase from './Firebase'
 import { getDisplayName } from './utils'
 
 export default WrappedComponent => {
-  const FirebaseConnect = props => (
-    <Firebase
-      firebaseApp={props.firebaseApp}
-      render={(firebaseProps, ref, firebaseApp) => (
-        <WrappedComponent firebaseApp={firebaseApp} ref={ref} {...props} />
+  const WithFirebase = props => (
+    <Firebase firebaseApp={props.firebaseApp}>
+      {(firebaseProps, firebaseRef, firebaseApp) => (
+        <WrappedComponent firebaseApp={firebaseApp} firebaseRef={firebaseRef} {...props} />
       )}
-    />
+    </Firebase>
   )
 
-  FirebaseConnect.WrappedComponent = WrappedComponent
-  FirebaseConnect.displayName = `FirebaseConnect(${getDisplayName(WrappedComponent)})`
-  FirebaseConnect.propTypes = {
+  WithFirebase.WrappedComponent = WrappedComponent
+  WithFirebase.displayName = `WithFirebase(${getDisplayName(WrappedComponent)})`
+  WithFirebase.propTypes = {
     firebaseApp: PropTypes.instanceOf(firebase.app.App),
   }
 
-  return FirebaseConnect
+  return WithFirebase
 }

--- a/src/withFirebase.js
+++ b/src/withFirebase.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import firebase from 'firebase/app'
+import Firebase from './Firebase'
+import { getDisplayName } from './utils'
+
+export default WrappedComponent => {
+  const FirebaseConnect = props => (
+    <Firebase
+      firebaseApp={props.firebaseApp}
+      render={(firebaseProps, ref, firebaseApp) => (
+        <WrappedComponent firebaseApp={firebaseApp} ref={ref} {...props} />
+      )}
+    />
+  )
+
+  FirebaseConnect.WrappedComponent = WrappedComponent
+  FirebaseConnect.displayName = `FirebaseConnect(${getDisplayName(WrappedComponent)})`
+  FirebaseConnect.propTypes = {
+    firebaseApp: PropTypes.instanceOf(firebase.app.App),
+  }
+
+  return FirebaseConnect
+}

--- a/tests/Provider-test.js
+++ b/tests/Provider-test.js
@@ -20,7 +20,7 @@ test('Should use firebaseApp from context if provided', assert => {
   const container = renderIntoDocument(
     <Provider firebaseApp={firebaseApp}>
       <WrappedComponent />
-    </Provider>
+    </Provider>,
   )
 
   const stub = findRenderedComponentWithType(container, WrappedComponent)

--- a/tests/connect-test.js
+++ b/tests/connect-test.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable import/no-extraneous-dependencies, react/no-find-dom-node */
 
 import 'jsdom-global/register'
 import React, { Component } from 'react'


### PR DESCRIPTION
## New feature: `<Firebase />` component
This will add the capability to dynamicly change the subscriptions on render.
Inspired by [Never Write Another HoC](https://www.youtube.com/watch?v=BcVAq3YFiuc&feature=share), a talk by @mjackson.

This will enable:

```jsx
const Header ({ userId }) => (
  <header>
    <Logo />
    <Firebase
      query={(ref, app) => ({ 
        username: `users/${userId}/name`,
        logout: () => app.auth().signOut(),
      })}
      render={({ username, logout }) => 
        <h1>Welcome {username}</h1>
        <button onClick={logout}>Logout</button>
      }
    />
  </header>
)

const Todos = () => (
  <Firebase query="todos" render={todos => todos &&
    <ul>
      {todos.map(todo => <li>{todo}</li>)}
    </ul>
  } />
)

const Toggle = () => 
  <Firebase
    query={ref => ({
      toggle: 'toggle',
      setToggle: toggle => ref('toggle', toggle)
    })}
    render={({ toggle, setToggle }) =>
      <input
        type="checkbox"
        value={toggle}
        onChange={event => setToggle(event.target.checked)}
      />
    }
  />
```

#### Before merge

- [ ] All tests should pass. Right now they expect `FirebaseConnect` to have access to the subscriptionState etc.
- [ ] New tests for Firebase.js
- [ ] Documentation in readme