### PR TITLE
Deep subscription comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   },
   "dependencies": {
     "invariant": "^2.0.0",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "shallowequal": "^1.0.2"
   },
   "peerDependencies": {
     "firebase": "^3.6.1 || ^4.0.0",

--- a/src/connect.js
+++ b/src/connect.js
@@ -3,14 +3,8 @@ import { Component, createElement } from 'react'
 import invariant from 'invariant'
 import firebase from 'firebase/app'
 import 'firebase/database'
-import {
-  createQueryRef,
-  getDisplayName,
-  mapValues,
-  mapSnapshotToValue,
-  pickBy,
-  deepEqual,
-} from './utils'
+import shallowEqual from 'shallowequal'
+import { createQueryRef, getDisplayName, mapValues, pickBy, mapSnapshotToValue } from './utils'
 
 const defaultMergeProps = (ownProps, firebaseProps) => ({
   ...ownProps,
@@ -25,9 +19,8 @@ const defaultMapFirebaseToProps = (props, ref, firebaseApp) => ({
 })
 
 export default (mapFirebaseToProps = defaultMapFirebaseToProps, mergeProps = defaultMergeProps) => {
-  const mapFirebase = typeof mapFirebaseToProps === 'function'
-    ? mapFirebaseToProps
-    : () => mapFirebaseToProps
+  const mapFirebase =
+    typeof mapFirebaseToProps === 'function' ? mapFirebaseToProps : () => mapFirebaseToProps
 
   const computeSubscriptions = (props, ref, firebaseApp) => {
     const firebaseProps = mapFirebase(props, ref, firebaseApp)
@@ -71,7 +64,7 @@ export default (mapFirebaseToProps = defaultMapFirebaseToProps, mergeProps = def
         const removedSubscriptions = pickBy(subscriptions, (path, key) => !nextSubscriptions[key])
         const changedSubscriptions = pickBy(
           nextSubscriptions,
-          (path, key) => subscriptions[key] && !deepEqual(subscriptions[key], path)
+          (path, key) => subscriptions[key] && !shallowEqual(subscriptions[key], path)
         )
 
         this.unsubscribe({ ...removedSubscriptions, ...changedSubscriptions })

--- a/src/connect.js
+++ b/src/connect.js
@@ -3,7 +3,14 @@ import { Component, createElement } from 'react'
 import invariant from 'invariant'
 import firebase from 'firebase/app'
 import 'firebase/database'
-import { createQueryRef, getDisplayName, mapValues, mapSnapshotToValue, pickBy } from './utils'
+import {
+  createQueryRef,
+  getDisplayName,
+  mapValues,
+  mapSnapshotToValue,
+  pickBy,
+  deepEqual,
+} from './utils'
 
 const defaultMergeProps = (ownProps, firebaseProps) => ({
   ...ownProps,
@@ -64,7 +71,7 @@ export default (mapFirebaseToProps = defaultMapFirebaseToProps, mergeProps = def
         const removedSubscriptions = pickBy(subscriptions, (path, key) => !nextSubscriptions[key])
         const changedSubscriptions = pickBy(
           nextSubscriptions,
-          (path, key) => subscriptions[key] && subscriptions[key] !== path
+          (path, key) => subscriptions[key] && !deepEqual(subscriptions[key], path)
         )
 
         this.unsubscribe({ ...removedSubscriptions, ...changedSubscriptions })

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,3 +39,5 @@ export const mapSnapshotToValue = snapshot => {
 
   return result
 }
+
+export const deepEqual = (object1, object2) => JSON.stringify(object1) === JSON.stringify(object2)

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,5 +39,3 @@ export const mapSnapshotToValue = snapshot => {
 
   return result
 }
-
-export const deepEqual = (object1, object2) => JSON.stringify(object1) === JSON.stringify(object2)


### PR DESCRIPTION
When using object subscriptions (`path`, `orderByChild`, `equalTo`, etc..) it was unsubscribing and re-subscribing if any parent `props` changed, even when the resulting subscription map didn't change at all.

Feel free to reimplement the `utils.deepEqual` "algo". Just used a quick hack to solve my problem.
I had an infinite render loop before this patch. Works in my app without issues.

thanks for your time, and awesome concept 😄 👏 